### PR TITLE
Fix missing index on migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rspec
+  - rubocop-rails
 
 AllCops:
   NewCops: enable

--- a/app/models/json_web_token.rb
+++ b/app/models/json_web_token.rb
@@ -10,6 +10,6 @@ class JsonWebToken
 
   def self.decode(token)
     decoded = JWT.decode(token, SECRET_KEY)[0]
-    HashWithIndifferentAccess.new decoded
+    ActiveSupport::HashWithIndifferentAccess.new decoded
   end
 end

--- a/db/migrate/20221018051310_create_users.rb
+++ b/db/migrate/20221018051310_create_users.rb
@@ -8,6 +8,8 @@ class CreateUsers < ActiveRecord::Migration[7.0]
       t.integer :role, default: 0
 
       t.timestamps
+
+      t.index "slug", name: "user_slug_index", unique: true
     end
   end
 end

--- a/db/migrate/20221202110535_create_accounts.rb
+++ b/db/migrate/20221202110535_create_accounts.rb
@@ -7,6 +7,9 @@ class CreateAccounts < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.references :user, null: false, index: true, on_delete: :cascade
+
+      t.index ["slug", "user_id"], name: "user_id_accounts_slug_index", unique: true
+      t.index ["name", "user_id"], name: "user_id_accounts_name_index", unique: true
     end
   end
 end

--- a/db/migrate/20221202164508_create_categories.rb
+++ b/db/migrate/20221202164508_create_categories.rb
@@ -7,6 +7,9 @@ class CreateCategories < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.references :user, null: false, index: true, on_delete: :cascade
+
+      t.index ["slug", "user_id"], name: "user_id_categories_slug_index", unique: true
+      t.index ["name", "user_id"], name: "user_id_categories_name_index", unique: true
     end
   end
 end

--- a/db/migrate/20221205125856_create_default_bills.rb
+++ b/db/migrate/20221205125856_create_default_bills.rb
@@ -8,6 +8,9 @@ class CreateDefaultBills < ActiveRecord::Migration[7.0]
       t.timestamps
 
       t.references :user, null: false, index: true, on_delete: :cascade
+
+      t.index ["slug", "user_id"], name: "user_id_default_bills_slug_index", unique: true
+      t.index ["name", "user_id"], name: "user_id_default_bills_name_index", unique: true
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_125856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["name", "user_id"], name: "user_id_accounts_name_index", unique: true
+    t.index ["slug", "user_id"], name: "user_id_accounts_slug_index", unique: true
     t.index ["slug"], name: "index_accounts_on_slug"
     t.index ["user_id"], name: "index_accounts_on_user_id"
   end
@@ -30,6 +32,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_125856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["name", "user_id"], name: "user_id_categories_name_index", unique: true
+    t.index ["slug", "user_id"], name: "user_id_categories_slug_index", unique: true
     t.index ["slug"], name: "index_categories_on_slug"
     t.index ["user_id"], name: "index_categories_on_user_id"
   end
@@ -42,6 +46,8 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_125856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
+    t.index ["name", "user_id"], name: "user_id_default_bills_name_index", unique: true
+    t.index ["slug", "user_id"], name: "user_id_default_bills_slug_index", unique: true
     t.index ["slug"], name: "index_default_bills_on_slug"
     t.index ["user_id"], name: "index_default_bills_on_user_id"
   end
@@ -55,6 +61,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_05_125856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["slug"], name: "user_slug_index", unique: true
   end
 
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,7 +22,9 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
+# rubocop:disable Rails/FilePath
 Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+# rubocop:enable Rails/FilePath
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -33,7 +35,8 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_path = Rails.root.join('spec/fixtures')
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false


### PR DESCRIPTION
Depois de adicionado a extensão do Rubocop-Rails, ele apontou alguns errors nas migrations, e isso é melhor explicado aqui:
[Rails/UniqueValidationWithoutIndex should not fail when using scope](https://github.com/rubocop/rubocop-rails/issues/231)